### PR TITLE
fix: simplify instructions for Kubernetes resume challenge

### DIFF
--- a/projects/kubernetes/cloud-resume-challenge.md
+++ b/projects/kubernetes/cloud-resume-challenge.md
@@ -8,139 +8,126 @@ title: "Web App Deployment in kubernetes(K8s) Cluster"
 
 ## Intro
 
-Imagine you are going to deploy an e-commerce website, it's crucial to consider the challenges of modern web application deployment and how containerization and Kubernetes (K8s) offer compelling solutions:
+This version of the cloud resume challenge uses Kubernetes. Kubernetes is a popular (but advanced!) tool for orchestrating workloads in the cloud. If you're completely new to the cloud, consider doing one of the original Cloud Resume Challenge's before this one. The challenge covers the Kubernetes way of solving the following cloud challenges: 
 
-- **Scalability:** How can your application automatically adjust to fluctuating traffic?
-- **Consistency:** How do you ensure your application runs the same across all environments?
-- **Availability:** How can you update your application with zero downtime?
+- **Scalability:** How does an application adjust to fluctuating traffic?
+- **Consistency:** How can you ensure an application is portable, and runs consistently in different environments?
+- **Availability:** How can you update an application in production with zero downtime?
 
-Containerization, using Docker, encapsulates your application and its environment, ensuring it runs consistently everywhere. Kubernetes, a container orchestration platform, automates deployment, scaling, and management, offering:
+The Kubernetes Cloud Resume Challenge uses two key technologies: Docker and Kubernetes. Containerization with Docker encapsulates your application and its environment, ensuring it runs consistently. Kubernetes, a container orchestration platform, automates the deployment, scaling, and management by: 
 
-- **Dynamic Scaling:** Adjusts application resources based on demand.
-- **Self-healing:** Restarts failed containers and reschedules them on healthy nodes.
-- **Seamless Updates & Rollbacks:** Enables zero-downtime updates and easy rollbacks.
+- Adjusting application resources based on demand
+- Restarting failed containers and reschedules them on healthy nodes.
+- Configuration of zero-downtime updates and easy rollbacks.
 
-By leveraging Kubernetes and containerization for your Cloud Resume Challenge, you embrace a scalable, consistent, and resilient deployment strategy. This not only demonstrates your technical acumen but aligns with modern DevOps practices.
+> **Thank you!** - To the KodeKloud team for helping to put together these instructions. You can dive into [KodeKloud's Docker Learning Path](https://kodekloud.com/learning-path/docker/) and [Kubernetes Learning Path by KodeKloud](https://kodekloud.com/learning-path/kubernetes/) to master Kubernetes, enhance your project and preparing you for a future in cloud computing and DevOps.
 
-Dive into [KodeKloud's Docker Learning Path](https://kodekloud.com/learning-path/docker/) and [Kubernetes Learning Path by KodeKloud](https://kodekloud.com/learning-path/kubernetes/) to master these technologies, enhancing your project and preparing you for a future in cloud computing and DevOps.
+## Prerequisites
 
+The following steps will require the following knowledge and/or tools installed on your machine: 
 
-## Challenge Guide
-
-### Prerequisites
-
-Before you embark on this journey, ensure you are equipped with:
-
-- **Docker and Kubernetes CLI Tools**: Essential for building, pushing Docker images, and managing Kubernetes resources.
+- **Docker and Kubernetes CLI**: Required to build and pushing Docker images, and also manage Kubernetes resources.
 - **Cloud Provider Account**: Access to AWS, Azure, or GCP for creating a Kubernetes cluster.
 - **GitHub Account**: For version control and implementing CI/CD pipelines.
-- **E-commerce Application Source Code and DB Scripts**: Available at [kodekloudhub/learning-app-ecommerce](https://github.com/kodekloudhub/learning-app-ecommerce). Familiarize yourself with the application structure and database scripts provided.
-
-## Step-by-Step Implementation
 
 ### Step 1: Certification
 
-**KodeKloud CKAD Course**: To ensure you have a solid understanding of Kubernetes concepts and practical experience, complete the [Certified Kubernetes Application Developer (CKAD) course by KodeKloud](https://www.kodekloud.com/p/kubernetes-certification-course). This course will equip you with the knowledge and skills needed to tackle this challenge effectively.
+Complete the [Certified Kubernetes Application Developer (CKAD) course by KodeKloud](https://www.kodekloud.com/p/kubernetes-certification-course). 
 
-### Step 2: Containerize Your E-Commerce Website and Database
+**Outcome**: A CKAD certification. 
 
-#### A. Web Application Containerization
+### Step 2: Containerize A Website
 
-1. **Create a Dockerfile**: Navigate to the root of the e-commerce application and create a Dockerfile. This file should instruct Docker to:
-   - Use `php:7.4-apache` as the base image.
-   - Install `mysqli` extension for PHP.
-   - Copy the application source code to `/var/www/html/`.
-   - Update database connection strings to point to a Kubernetes service named `mysql-service`.
-   - Expose port `80` to allow traffic to the web server.
+Kubernetes deploys applications packaged as containers. In this first step we'll create our container definitions for our workload.
 
-2. **Build and Push the Docker Image**:
-   - Execute `docker build -t yourdockerhubusername/ecom-web:v1 .` to build your image.
-   - Push it to Docker Hub with `docker push yourdockerhubusername/ecom-web:v1`.
-   - **Outcome**: Your web application Docker image is now available on Docker Hub.
+- Create a Dockerfile with a running web application, exposed on port `80`
 
-#### B. Database Containerization
+**Outcome**: A Dockerfile application. 
 
-- **Database Preparation**: Instead of containerizing the database yourself, you'll use the official MariaDB image. Prepare the database initialization script (`db-load-script.sql`) to be used with Kubernetes ConfigMaps or as an entrypoint script.
+### Step 3: Containerize A Database
 
-### Step 3: Set Up Kubernetes on a Public Cloud Provider
+Most applications need some form of state in a database, let's configure one. 
 
-- **Cluster Creation**: Choose AWS (EKS), Azure (AKS), or GCP (GKE) and follow their documentation to create a Kubernetes cluster. Ensure you have `kubectl` configured to interact with your cluster.
-- **Outcome**: A fully operational Kubernetes cluster ready for deployment.
+- Instead of containerizing a database, grab an official database image. 
+- Prepare a database initialization script to create any database schema.
 
-### Step 4: Deploy Your Website to Kubernetes
+**Outcome**: A database running in a docker container.
 
-- **Kubernetes Deployment**: Create a `website-deployment.yaml` defining a Deployment that uses the Docker image created in Step 1A. Ensure the Deployment specifies the necessary environment variables and mounts for the database connection.
-- **Outcome**: The e-commerce web application is running on Kubernetes, with pods managed by the Deployment.
+### Step 4: Push your containers to a registry
 
-### Step 5: Expose Your Website
+Push the created Docker image to a registry (e.g. DockerHub)
 
-- **Service Creation**: Define a `website-service.yaml` to create a Service of type `LoadBalancer`. This Service exposes your Deployment to the internet.
-- **Outcome**: An accessible URL or IP address for your web application.
+**Outcome**: Your application image stored in an image registry.
 
-### Step 6: Implement Configuration Management
+### Step 5: Set Up Kubernetes on a Public Cloud Provider
 
-**Task**: Add a feature toggle to the web application to enable a "dark mode" for the website.
 
-1. **Modify the Web Application**: Add a simple feature toggle in the application code (e.g., an environment variable `FEATURE_DARK_MODE` that enables a CSS dark theme).
-2. **Use ConfigMaps**: Create a ConfigMap named `feature-toggle-config` with the data `FEATURE_DARK_MODE=true`.
-3. **Deploy ConfigMap**: Apply the ConfigMap to your Kubernetes cluster.
-4. **Update Deployment**: Modify the `website-deployment.yaml` to include the environment variable from the ConfigMap.
-5. **Outcome**: Your website should now render in dark mode, demonstrating how ConfigMaps manage application features.
+With your containers and Kubernetes configurations written, it's time to deploy them to the cloud. 
 
-### Step 7: Scale Your Application
+> **Note:** At this point you have a choice. You can use a tool like [MiniKube](https://minikube.sigs.k8s.io/) to experiment with your YAML configurations locally. Or, you can deploy a cluster in the cloud to test your configuration changes. 
 
-**Task**: Prepare for a marketing campaign expected to triple traffic.
+- Choose AWS (EKS), Azure (AKS), or GCP (GKE) and follow their documentation to create a Kubernetes cluster. 
+- Ensure you have `kubectl` configured to interact with your cluster.
 
-1. **Evaluate Current Load**: Use `kubectl get pods` to assess the current number of running pods.
-2. **Scale Up**: Increase replicas in your deployment or use `kubectl scale deployment/ecom-web --replicas=6` to handle the increased load.
-3. **Monitor Scaling**: Observe the deployment scaling up with `kubectl get pods`.
-4. **Outcome**: The application scales up to handle increased traffic, showcasing Kubernetes' ability to manage application scalability dynamically.
+**Outcome**: A deployed Kubernetes cluster.
 
-### Step 8: Perform a Rolling Update
+### Step 6: Create your Kubernetes configurations
 
-**Task**: Update the website to include a new promotional banner for the marketing campaign.
+Kubernetes doesn't configure containers directly, but instead uses various "manifest" files and abstraction layers. 
 
-1. **Update Application**: Modify the web application's code to include the promotional banner.
-2. **Build and Push New Image**: Build the updated Docker image as `yourdockerhubusername/ecom-web:v2` and push it to Docker Hub.
-3. **Rolling Update**: Update `website-deployment.yaml` with the new image version and apply the changes.
-4. **Monitor Update**: Use `kubectl rollout status deployment/ecom-web` to watch the rolling update process.
-5. **Outcome**: The website updates with zero downtime, demonstrating rolling updates' effectiveness in maintaining service availability.
+- Create a Kubernetes [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) that references your Docker image in your registry
+- Configure environment variables or mounts to allow your application to talk with your database.
 
-### Step 9: Roll Back a Deployment
+**Outcome**: Your application is running on Kubernetes, with pods managed by the Deployment.
 
-**Task**: Suppose the new banner introduced a bug. Roll back to the previous version.
+### Step 7: Create your Kubernetes service configuration
 
-1. **Identify Issue**: After deployment, monitoring tools indicate a problem affecting user experience.
-2. **Roll Back**: Execute `kubectl rollout undo deployment/ecom-web` to revert to the previous deployment state.
-3. **Verify Rollback**: Ensure the website returns to its pre-update state without the promotional banner.
-4. **Outcome**: The application's stability is quickly restored, highlighting the importance of rollbacks in deployment strategies.
+With only a deployment configuration, your application will not be accessible from the outside world at a stable URL. So, you'll need a [Service](https://kubernetes.io/docs/concepts/services-networking/service/). 
 
-### Step 10: Autoscale Your Application
+- Update your manifests to create a load balancer service. 
 
-**Task**: Automate scaling based on CPU usage to handle unpredictable traffic spikes.
+**Outcome**: An accessible URL or IP address for your web application.
 
-1. **Implement HPA**: Create a Horizontal Pod Autoscaler targeting 50% CPU utilization, with a minimum of 2 and a maximum of 10 pods.
-2. **Apply HPA**: Execute `kubectl autoscale deployment ecom-web --cpu-percent=50 --min=2 --max=10`.
-3. **Simulate Load**: Use a tool like Apache Bench to generate traffic and increase CPU load.
-4. **Monitor Autoscaling**: Observe the HPA in action with `kubectl get hpa`.
-5. **Outcome**: The deployment automatically adjusts the number of pods based on CPU load, showcasing Kubernetes' capability to maintain performance under varying loads.
+### Step 8: Implement Configuration Management
+
+With your app running, let's demonstrate how to configure your running application using a [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/). 
+
+- Add a feature toggle to the web application to enable a "dark mode" for the website.
+
+**Outcome**: Your website should now render in dark mode.
+
+### Step 9: Scale Your Application
+
+With your app running, you need to prepare for a marketing campaign and expect triple traffic. 
+
+- Explore `kubectl` to run a command to manually scale the number of pods for your web application. 
+- Once you've figured out how to scale manually, configure autoscaling. 
+
+**Outcome**: The deployment automatically adjusts the number of pods based on CPU load, showcasing Kubernetes' capability to maintain performance under varying loads.
+
+### Step 10: Rolling Update and Rollback
+
+- Update the website to include a new promotional banner for the marketing campaign, apply the change using a rolling update. 
+- Imagine the new banner you deployed introduced a bug. Roll back to the previous version.
+
+**Outcome** Documented commands in a "runbook" (essentially, a document in your repo) that explains how to rollout and rollback your application. 
 
 ### Step 11: Implement Liveness and Readiness Probes
 
-**Task**: Ensure the web application is restarted if it becomes unresponsive and doesn’t receive traffic until ready.
+If your app becomes unresponsive, you want to ensure it is restarted. 
 
-1. **Define Probes**: Add liveness and readiness probes to `website-deployment.yaml`, targeting an endpoint in your application that confirms its operational status.
-2. **Apply Changes**: Update your deployment with the new configuration.
-3. **Test Probes**: Simulate failure scenarios (e.g., manually stopping the application) and observe Kubernetes' response.
-4. **Outcome**: Kubernetes automatically restarts unresponsive pods and delays traffic to newly started pods until they're ready, enhancing the application's reliability and availability.
+- Add, or re-use an endpoint (url) in your application to confirm it's operational status. 
+- Ensure Kubernetes automatically restarts unresponsive pods and delays traffic to newly started pods until they're ready.
 
-### Step 12: Utilize ConfigMaps and Secrets
+**Outcome** Defined probes for your application.
 
-**Task**: Securely manage the database connection string and feature toggles without hardcoding them in the application.
+### Step 12: Utilize Secrets
 
-1. **Create Secret and ConfigMap**: For sensitive data like DB credentials, use a Secret. For non-sensitive data like feature toggles, use a ConfigMap.
-2. **Update Deployment**: Reference the Secret and ConfigMap in the deployment to inject these values into the application environment.
-3. **Outcome**: Application configuration is externalized and securely managed, demonstrating best practices in configuration and secret management.
+Ensure you're not hardcoding any passwords or database strings in your application by using a Secret. 
+
+- Reference your Secret in your manifest files / Deployment configuration. 
+
+**Outcome** No hardcoded secrets in your repo, or manifest definitions. 
 
 ### Step 13: Document Your Process
 
@@ -154,7 +141,6 @@ Add links to the Cloud Resume Challenge and KodeKloud sites as in the following.
 - **Cloud Resume Challenge**: A hands-on project designed to deepen your understanding of cloud services through the practical application of building and deploying a resume. This challenge is an excellent way to apply what you've learned in a real-world scenario, enhancing your cloud skills. For more details, visit [Cloud Resume Challenge](https://cloudresumechallenge.dev/).
 
 - **KodeKloud**: An interactive learning platform that offers a wide range of hands-on labs, courses, and real-world simulations tailored towards DevOps, Cloud, and software engineering practices. KodeKloud is an ideal resource for both beginners and experienced professionals looking to enhance their technical skills. Explore more at [KodeKloud](https://kodekloud.com/).
-
 
 ## Extra credit
 
@@ -183,3 +169,65 @@ For more details, follow [KodeKloud Helm Course](https://kodekloud.com/courses/h
 
 1. **GitHub Actions Workflow**: Create a `.github/workflows/deploy.yml` file to build the Docker image, push it to Docker Hub, and update the Kubernetes deployment upon push to the main branch.
 2. **Outcome**: Changes to the application are automatically built and deployed, showcasing an efficient CI/CD pipeline.
+
+## Appendix
+
+The following are move advanced hints to the above instructions. Explore if you're stuck, but we recommend you use your initiative first. 
+
+The below hints are based on: [kodekloudhub/learning-app-ecommerce](https://github.com/kodekloudhub/learning-app-ecommerce). 
+
+### Containerizing
+
+1. **Create a Dockerfile**: Navigate to the root of the e-commerce application and create a Dockerfile. This file should instruct Docker to:
+   - Use `php:7.4-apache` as the base image.
+   - Install `mysqli` extension for PHP.
+   - Copy the application source code to `/var/www/html/`.
+   - Update database connection strings to point to a Kubernetes service named `mysql-service`.
+   - Expose port `80` to allow traffic to the web server.
+
+2. **Build and Push the Docker Image**:
+   - Execute `docker build -t yourdockerhubusername/ecom-web:v1 .` to build your image.
+   - Push it to Docker Hub with `docker push yourdockerhubusername/ecom-web:v1`.
+   - **Outcome**: Your web application Docker image is now available on Docker Hub.
+
+### Configuration Management
+
+1. **Modify the Web Application**: Add a simple feature toggle in the application code (e.g., an environment variable `FEATURE_DARK_MODE` that enables a CSS dark theme).
+2. **Use ConfigMaps**: Create a ConfigMap named `feature-toggle-config` with the data `FEATURE_DARK_MODE=true`.
+3. **Deploy ConfigMap**: Apply the ConfigMap to your Kubernetes cluster.
+4. **Update Deployment**: Modify the `website-deployment.yaml` to include the environment variable from the ConfigMap.
+
+### Scaling Manually
+
+1. **Evaluate Current Load**: Use `kubectl get pods` to assess the current number of running pods.
+2. **Scale Up**: Increase replicas in your deployment or use `kubectl scale deployment/ecom-web --replicas=6` to handle the increased load.
+3. **Monitor Scaling**: Observe the deployment scaling up with `kubectl get pods`.
+4. **Outcome**: The application scales up to handle increased traffic, showcasing Kubernetes' ability to manage application scalability dynamically.
+
+#### Performing a Rolling Update
+
+1. **Update Application**: Modify the web application's code to include the promotional banner.
+2. **Build and Push New Image**: Build the updated Docker image as `yourdockerhubusername/ecom-web:v2` and push it to Docker Hub.
+3. **Rolling Update**: Update `website-deployment.yaml` with the new image version and apply the changes.
+4. **Monitor Update**: Use `kubectl rollout status deployment/ecom-web` to watch the rolling update process.
+
+### Rolling Back a Deployment
+
+1. **Identify Issue**: After deployment, monitoring tools indicate a problem affecting user experience.
+2. **Roll Back**: Execute `kubectl rollout undo deployment/ecom-web` to revert to the previous deployment state.
+3. **Verify Rollback**: Ensure the website returns to its pre-update state without the promotional banner.
+
+### Autoscaling An Application
+
+**Task**: Automate scaling based on CPU usage to handle unpredictable traffic spikes.
+
+1. **Implement HPA**: Create a Horizontal Pod Autoscaler targeting 50% CPU utilization, with a minimum of 2 and a maximum of 10 pods.
+2. **Apply HPA**: Execute `kubectl autoscale deployment ecom-web --cpu-percent=50 --min=2 --max=10`.
+3. **Simulate Load**: Use a tool like Apache Bench to generate traffic and increase CPU load.
+4. **Monitor Autoscaling**: Observe the HPA in action with `kubectl get hpa`.
+
+### Liveness and Readiness Probes
+
+1. **Define Probes**: Add liveness and readiness probes to `website-deployment.yaml`, targeting an endpoint in your application that confirms its operational status.
+2. **Apply Changes**: Update your deployment with the new configuration.
+3. **Test Probes**: Simulate failure scenarios (e.g., manually stopping the application) and observe Kubernetes' response.


### PR DESCRIPTION
Raising a PR that generalises some of the steps. I've not removed the helper text, but pushed to the bottom as an appendix. I would argue these even could/should be moved to another page as that's more in the spirit of the cloud resume challenge, to not give explicit instructions. The bulk of the PR is moving steps that are very specific to the KodeKloud example (https://github.com/kodekloudhub/learning-app-ecommerce to the bottom) to the bottom. This gives the reader the opportunity to scroll down to those for reference, but keeps the steps more generic. 

|Before|After|
|-|-|
|![image](https://github.com/cloudresumechallenge/projects/assets/5528307/084abf62-2369-404f-8f7f-a85445f39959)|![image](https://github.com/cloudresumechallenge/projects/assets/5528307/03d0b41d-f2bc-4584-a8a1-819dcb83fde6)|

**Notable changes:**
1. Add a note before the "deploy to cloud" step about MiniKube based development.
2. Consolidate some of the rollout/rollback steps (they felt too "pithy" as individual steps to me). 
3. Ensure each step has a clear "outcome" statement.
4. Add a bit of context to each step about what we've done, and are about to do. 


Here's a Loom video talking through the changes, purpose and before/after. 

https://www.loom.com/share/f8ad0dfc598a4258973202fca074b8e2
